### PR TITLE
fix: pass providers from constructor to onnx_session

### DIFF
--- a/nudenet/nudenet.py
+++ b/nudenet/nudenet.py
@@ -149,7 +149,7 @@ class NudeDetector:
             os.path.join(os.path.dirname(__file__), "320n.onnx")
             if not model_path
             else model_path,
-            # providers=C.get_available_providers() if not providers else providers,
+            providers=C.get_available_providers() if not providers else providers,
         )
         model_inputs = self.onnx_session.get_inputs()
 


### PR DESCRIPTION
Found out the providers in the constructor has not been passed to onnx session, disabling the detector from using gpu.

Not sure if the change was intended.